### PR TITLE
Fix spec for Bitcoin::Network::Pool#allocate_peer_id

### DIFF
--- a/spec/bitcoin/network/pool_spec.rb
+++ b/spec/bitcoin/network/pool_spec.rb
@@ -37,8 +37,10 @@ describe Bitcoin::Network::Pool do
       subject {
         pool.started = true
         allow(pool).to receive(:connect).and_return(nil)
-        pool.handle_close_peer(peer2)
-        pool.handle_new_peer(peer2)
+        # delete second peer and register again.
+        peer = pool.peers[1]
+        pool.handle_close_peer(peer)
+        pool.handle_new_peer(peer)
         pool
       }
       it 'should allocate peer id' do


### PR DESCRIPTION
Fix spec failure.

```
1) Bitcoin::Network::Pool#allocate_peer_id when allocate again after disconnect should allocate peer id
     Failure/Error: expect(subject.peers[0].id).to eq(0)
     
       expected: 0
            got: 1
     
       (compared using ==)
     # ./spec/bitcoin/network/pool_spec.rb:46:in `block (4 levels) in <top (required)>'
```
