### PR TITLE
Fix creating a wallet after changing Bitcoin.chain_params fails. (#31)

### DIFF
--- a/lib/bitcoin/rpc/request_handler.rb
+++ b/lib/bitcoin/rpc/request_handler.rb
@@ -105,14 +105,14 @@ module Bitcoin
       # wallet api
 
       # create wallet
-      def createwallet(wallet_id = 1, wallet_path_prefix = Bitcoin::Wallet::Base::DEFAULT_PATH_PREFIX)
+      def createwallet(wallet_id = 1, wallet_path_prefix = Bitcoin::Wallet::Base.default_path_prefix)
         wallet = Bitcoin::Wallet::Base.create(wallet_id, wallet_path_prefix)
         node.wallet = wallet unless node.wallet
         {wallet_id: wallet.wallet_id, mnemonic: wallet.master_key.mnemonic}
       end
 
       # get wallet list.
-      def listwallets(wallet_path_prefix = Bitcoin::Wallet::Base::DEFAULT_PATH_PREFIX)
+      def listwallets(wallet_path_prefix = Bitcoin::Wallet::Base.default_path_prefix)
         Bitcoin::Wallet::Base.wallet_paths(wallet_path_prefix)
       end
 

--- a/lib/bitcoin/wallet/base.rb
+++ b/lib/bitcoin/wallet/base.rb
@@ -8,7 +8,6 @@ module Bitcoin
       attr_reader :db
       attr_reader :path
 
-      DEFAULT_PATH_PREFIX = "#{Bitcoin.base_dir}/db/wallet/"
       VERSION = 1
 
       # get wallet dir path
@@ -21,7 +20,7 @@ module Bitcoin
       # @param [String] wallet_id new wallet id.
       # @param [String] path_prefix wallet file path prefix.
       # @return [Bitcoin::Wallet::Base] the wallet
-      def self.create(wallet_id = 1, path_prefix = DEFAULT_PATH_PREFIX)
+      def self.create(wallet_id = 1, path_prefix = default_path_prefix)
         raise ArgumentError, "wallet_id : #{wallet_id} already exist." if self.exist?(wallet_id, path_prefix)
         w = self.new(wallet_id, path_prefix)
         # generate seed
@@ -34,19 +33,19 @@ module Bitcoin
 
       # load wallet with specified +wallet_id+
       # @return [Bitcoin::Wallet::Base] the wallet
-      def self.load(wallet_id, path_prefix = DEFAULT_PATH_PREFIX)
+      def self.load(wallet_id, path_prefix = default_path_prefix)
         raise ArgumentError, "wallet_id : #{wallet_id} dose not exist." unless self.exist?(wallet_id, path_prefix)
         self.new(wallet_id, path_prefix)
       end
 
       # get wallets path
       # @return [Array] Array of paths for each wallet dir.
-      def self.wallet_paths(path_prefix = DEFAULT_PATH_PREFIX)
+      def self.wallet_paths(path_prefix = default_path_prefix)
         Dir.glob("#{path_prefix}wallet*/").sort
       end
 
       # get current wallet
-      def self.current_wallet(path_prefix = DEFAULT_PATH_PREFIX)
+      def self.current_wallet(path_prefix = default_path_prefix)
         path = wallet_paths.first # TODO default wallet selection
         return nil unless path
         wallet_id = path.delete(path_prefix + '/wallet').delete('/').to_i

--- a/lib/bitcoin/wallet/base.rb
+++ b/lib/bitcoin/wallet/base.rb
@@ -11,6 +11,11 @@ module Bitcoin
       DEFAULT_PATH_PREFIX = "#{Bitcoin.base_dir}/db/wallet/"
       VERSION = 1
 
+      # get wallet dir path
+      def self.default_path_prefix
+        "#{Bitcoin.base_dir}/db/wallet/"
+      end
+
       # Create new wallet. If wallet already exist, throw error.
       # The wallet generates a seed using SecureRandom and store to db at initialization.
       # @param [String] wallet_id new wallet id.

--- a/spec/bitcoin/wallet/wallet_spec.rb
+++ b/spec/bitcoin/wallet/wallet_spec.rb
@@ -2,6 +2,29 @@ require 'spec_helper'
 
 describe Bitcoin::Wallet do
 
+  describe '#default_path_prefix' do
+    context 'testnet', network: :testnet do
+      subject { Bitcoin::Wallet::Base.default_path_prefix }
+
+      it { is_expected.to eq "#{Dir.home}/.bitcoinrb/testnet/db/wallet/" }
+    end
+
+    context 'regtest', network: :regtest do
+      subject { Bitcoin::Wallet::Base.default_path_prefix }
+
+      it { is_expected.to eq "#{Dir.home}/.bitcoinrb/regtest/db/wallet/" }
+    end
+
+    context 'change network from regtest to testnet', network: :regtest do
+      it 'should return path with network prefix' do
+        expect(Bitcoin::Wallet::Base.default_path_prefix).to eq "#{Dir.home}/.bitcoinrb/regtest/db/wallet/"
+        Bitcoin.chain_params = :testnet
+        expect(Bitcoin::Wallet::Base.default_path_prefix).to eq "#{Dir.home}/.bitcoinrb/testnet/db/wallet/"
+      end
+    end
+
+  end
+
   describe '#load' do
     context 'existing wallet' do
       subject {


### PR DESCRIPTION
This PR solve #31.

I run below, it is complete.

```
$ ./bin/console 
irb(main):001:0> wallet = Bitcoin::Wallet::Base.create(99999)
=> #<Bitcoin::Wallet::Base:0x00007fc72d101ef8 @path="/Users/okumura/.bitcoinrb/mainnet/db/wallet/wallet99999/", @db=#<Bitcoin::Wallet::DB:0x00007fc72c9f1dc0 @level_db=<LevelDB::DB "/Users/okumura/.bitcoinrb/mainnet/db/wallet/wallet99999/">, @master_key=#<Bitcoin::Wallet::MasterKey:0x00007fc72d0b4860 @mnemonic=["piece", "return", "maid", "learn", "dish", "stereo", "snow", "melt", "bounce", "lottery", "shock", "empty", "miss", "govern", "carpet", "tail", "turn", "often", "junior", "monster", "tell", "warrior", "grab", "candy"], @seed="67c0098389f99da10a5d15f7b65b9f095d60f77c6a1bff4a0b7185c6f09482872dab3ee80235791cccc5eab540a12b2e52bec0ba81b551c35a30d3114f7fe983", @encrypted=false, @salt="">>, @wallet_id=99999>
irb(main):002:0> wallet.close
=> true
irb(main):003:0> Bitcoin.chain_params = :regtest
=> :regtest
irb(main):004:0> wallet = Bitcoin::Wallet::Base.create(99999)
=> #<Bitcoin::Wallet::Base:0x0000000105731b20 @path="/Users/okumura/.bitcoinrb/regtest/db/wallet/wallet99999/", @db=#<Bitcoin::Wallet::DB:0x0000000105731aa8 @level_db=<LevelDB::DB "/Users/okumura/.bitcoinrb/regtest/db/wallet/wallet99999/">, @master_key=#<Bitcoin::Wallet::MasterKey:0x00000001056ba458 @mnemonic=["iron", "tower", "speak", "identify", "enlist", "crucial", "bracket", "multiply", "confirm", "about", "width", "behind", "melody", "output", "judge", "payment", "doctor", "come", "capable", "remove", "liquid", "claw", "invest", "electric"], @seed="d9c308ff5bc44cec4499e71467cb70f215fd8b57e08d7ed44fdd6369df5a1945992000ef51513401360f65b068db7a37869637f3984ab172da5bfc41c4e6ed73", @encrypted=false, @salt="">>, @wallet_id=99999>
irb(main):005:0> wallet.close
=> true
```