### PR TITLE
Performance in bitcoin key generation

### DIFF
--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -18,7 +18,7 @@ module Bitcoin
 
     TYPES = {uncompressed: 0x00, compressed: 0x01, p2pkh: 0x10, p2wpkh: 0x11, pw2pkh_p2sh: 0x12}
 
-    MIN_PRIV_KEy_MOD_ORDER = 0x01
+    MIN_PRIV_KEY_MOD_ORDER = 0x01
     # Order of secp256k1's generator minus 1.
     MAX_PRIV_KEY_MOD_ORDER = ECDSA::Group::Secp256k1.order - 1
 
@@ -259,7 +259,7 @@ module Bitcoin
     # check private key range.
     def validate_private_key_range(private_key)
       value = private_key.to_i(16)
-      MIN_PRIV_KEy_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
+      MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
     end
 
     # Supported violations include negative integers, excessive padding, garbage

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -253,9 +253,7 @@ module Bitcoin
     # @param [Boolean] compressed pubkey compressed?
     # @return [String] a pubkey which generate from privkey
     def generate_pubkey(privkey, compressed: true)
-      public_key = ECDSA::Group::Secp256k1.generator.multiply_by_scalar(privkey.to_i(16))
-      pubkey = ECDSA::Format::PointOctetString.encode(public_key, compression: compressed)
-      pubkey.bth
+      @secp256k1_module.generate_pubkey(privkey, compressed: compressed)
     end
 
     # check private key range.

--- a/lib/bitcoin/secp256k1/ruby.rb
+++ b/lib/bitcoin/secp256k1/ruby.rb
@@ -22,6 +22,11 @@ module Bitcoin
         Bitcoin::Key.new(priv_key: privkey, pubkey: pubkey, compressed: compressed)
       end
 
+      def generate_pubkey(privkey, compressed: true)
+        public_key = ECDSA::Group::Secp256k1.generator.multiply_by_scalar(privkey.to_i(16))
+        ECDSA::Format::PointOctetString.encode(public_key, compression: compressed).bth
+      end
+
       # sign data.
       # @param [String] data a data to be signed with binary format
       # @param [String] privkey a private key using sign

--- a/spec/bitcoin/secp256k1/native_spec.rb
+++ b/spec/bitcoin/secp256k1/native_spec.rb
@@ -44,6 +44,14 @@ describe Bitcoin::Secp256k1::Native, use_secp256k1: true do
     end
   end
 
+  describe '#generate_pubkey' do
+    subject { Bitcoin::Secp256k1::Native.generate_pubkey(privkey, compressed: true) }
+
+    let(:privkey) { '206f3acb5b7ac66dacf87910bb0b04bed78284b9b50c0d061705a44447a947ff' }
+
+    it { is_expected.to eq '020025aeb645b64b632c91d135683e227cb508ebb1766c65ee40405f53b8f1bb3a' }
+  end
+
   describe '#sign_data/#verify_data' do
     it 'should be signed' do
       message = 'message'

--- a/spec/bitcoin/secp256k1/ruby_spec.rb
+++ b/spec/bitcoin/secp256k1/ruby_spec.rb
@@ -44,6 +44,14 @@ describe Bitcoin::Secp256k1::Ruby do
     end
   end
 
+  describe '#generate_pubkey' do
+    subject { Bitcoin::Secp256k1::Ruby.generate_pubkey(privkey, compressed: true) }
+
+    let(:privkey) { '206f3acb5b7ac66dacf87910bb0b04bed78284b9b50c0d061705a44447a947ff' }
+
+    it { is_expected.to eq '020025aeb645b64b632c91d135683e227cb508ebb1766c65ee40405f53b8f1bb3a' }
+  end
+
   describe '#sign_data/#verify_data', use_secp256k1: true do
     it 'should be signed' do
       message = 'message'.htb

--- a/spec/bitcoin/wallet/wallet_spec.rb
+++ b/spec/bitcoin/wallet/wallet_spec.rb
@@ -27,11 +27,14 @@ describe Bitcoin::Wallet do
 
   describe '#load' do
     context 'existing wallet' do
-      subject {
+      subject { Bitcoin::Wallet::Base.load(1, TEST_WALLET_PATH)}
+
+      before do
         wallet = create_test_wallet
         wallet.close
-        Bitcoin::Wallet::Base.load(1, TEST_WALLET_PATH)
-      }
+      end
+      after { subject.close }
+
       it 'should return wallet' do
         expect(subject.wallet_id).to eq(1)
         expect(subject.path).to eq(test_wallet_path(1))


### PR DESCRIPTION
This PR makes Bitcoin::Key generation faster in case of using libsecp256k1 library.

Up to now, `Bitcoin::Key#generate_pubkey` has been based on pure Ruby implementation from 'ecdsa' gem. This PR change the method so that it may use native implementation in libsecp256k1( if libsecp256k1 library has been installed).

before:

```
irb(main):001:0> require "benchmark"
=> true
irb(main):002:0> puts Benchmark.measure { Bitcoin::Key.new(priv_key: "206f3acb5b7ac66dacf87910bb0b04bed78284b9b50c0d061705a44447a947ff") }
[Warning] Use key_type parameter instead of compressed. compressed parameter removed in the future.
  0.100302   0.001502   0.101804 (  0.104396)
=> nil

```

after:

```
irb(main):001:0> require "benchmark"
=> true
irb(main):002:0> puts Benchmark.measure { Bitcoin::Key.new(priv_key: "206f3acb5b7ac66dacf87910bb0b04bed78284b9b50c0d061705a44447a947ff") }
[Warning] Use key_type parameter instead of compressed. compressed parameter removed in the future.
  0.010627   0.001514   0.012141 (  0.016667)
```
