### PR TITLE
SPVChain#find_entry_by_hash raises UNEXPECTED error

### DIFF
--- a/lib/bitcoin/store/spv_chain.rb
+++ b/lib/bitcoin/store/spv_chain.rb
@@ -36,6 +36,7 @@ module Bitcoin
       # find block entry with the specified hash
       def find_entry_by_hash(hash)
         payload = db.get_entry_payload_from_hash(hash)
+        return nil unless payload
         ChainEntry.parse_from_payload(payload)
       end
 

--- a/spec/bitcoin/store/spv_chain_spec.rb
+++ b/spec/bitcoin/store/spv_chain_spec.rb
@@ -5,10 +5,39 @@ require 'fileutils'
 describe Bitcoin::Store::SPVChain do
 
   let (:chain) { create_test_chain }
-  subject { chain }
   after { chain.db.close }
 
+  describe '#find_entry_by_hash' do
+    subject { chain.find_entry_by_hash(target) }
+
+    let(:next_header) do
+      Bitcoin::BlockHeader.parse_from_payload(
+        '0100000043497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea3309' \
+        '00000000bac8b0fa927c0ac8234287e33c5f74d38d354820e24756ad709d7038' \
+        'fc5f31f020e7494dffff001d03e4b672'.htb
+      )
+    end
+    let(:target) {'06128e87be8b1b4dea47a7247d5528d2702c96826c7a648497e773b800000000' }
+
+    before do
+      chain.append_header(next_header)
+    end
+
+    it 'return correct ChainEntry' do
+      expect(subject.header).to eq next_header
+      expect(subject.height).to eq 1
+    end
+
+    context 'header is not stored' do
+      let(:target) {'0000000000000000000000000000000000000000000000000000000000000000' }
+
+      it { expect(subject).to be_nil }
+    end
+  end
+
   describe '#append_header' do
+    subject { chain }
+
     context 'correct header' do
       it 'should store data' do
         genesis = subject.latest_block


### PR DESCRIPTION
SPVChain#find_entry_by_hash raises the following RuntimeError when a hash is not stored in the database. (It occurs on blockchain reorganization.)

```
     TypeError:
       no implicit conversion of nil into String
     # ./lib/bitcoin/store/chain_entry.rb:43:in `initialize'
     # ./lib/bitcoin/store/chain_entry.rb:43:in `new'
     # ./lib/bitcoin/store/chain_entry.rb:43:in `parse_from_payload'
     # ./lib/bitcoin/store/spv_chain.rb:40:in `find_entry_by_hash'
```

on the other hand, SPVChain#append_header(header) seems to design that  SPVChain#find_entry_by_hash returns nil (or false) and #append_header raise error "header's previous hash..."

```
unless find_entry_by_hash(header.block_hash)
    # TODO implements recovery process
    raise "header's previous hash(#{header.prev_hash}) does not match current best block's(#{best_block.block_hash})."
end
```