### PR TITLE
OpenAssets::MarkerOutput#open_assets_marker? should not raise error

### DIFF
--- a/lib/bitcoin/util.rb
+++ b/lib/bitcoin/util.rb
@@ -31,6 +31,7 @@ module Bitcoin
       end
     end
 
+    # @return an integer for a valid payload, otherwise nil
     def unpack_var_int(payload)
       case payload.unpack('C').first
       when 0xfd
@@ -44,15 +45,16 @@ module Bitcoin
       end
     end
 
+    # @return an integer for a valid payload, otherwise nil
     def unpack_var_int_from_io(buf)
-      uchar = buf.read(1).unpack('C').first
+      uchar = buf.read(1)&.unpack('C')&.first
       case uchar
       when 0xfd
-        buf.read(2).unpack('v').first
+        buf.read(2)&.unpack('v')&.first
       when 0xfe
-        buf.read(4).unpack('V').first
+        buf.read(4)&.unpack('V')&.first
       when 0xff
-        buf.read(8).unpack('Q').first
+        buf.read(8)&.unpack('Q')&.first
       else
         uchar
       end

--- a/spec/bitcoin/util_spec.rb
+++ b/spec/bitcoin/util_spec.rb
@@ -28,6 +28,20 @@ describe Bitcoin::Util do
       expect(util.unpack_var_int([0xfd, 0xfd, 0x00].pack('C*')).first).to eq(253)
       expect(util.unpack_var_int([0xfd, 0xff, 0xff].pack('C*')).first).to eq(65535)
       expect(util.unpack_var_int([0xfe, 0x00, 0x00, 0x01, 0x00].pack('C*')).first).to eq(65536)
+      expect(util.unpack_var_int([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff].pack('C*')).first).to eq(0xffffffffffffffff)
+      expect(util.unpack_var_int([0xff].pack('C*')).first).to be_nil
+      expect(util.unpack_var_int('').first).to be_nil
+    end
+
+    it 'should unpack var int from io' do
+      expect(util.unpack_var_int_from_io(StringIO.new([0x04].pack('C')))).to eq(4)
+      expect(util.unpack_var_int_from_io(StringIO.new([0xfc].pack('C')))).to eq(252)
+      expect(util.unpack_var_int_from_io(StringIO.new([0xfd, 0xfd, 0x00].pack('C*')))).to eq(253)
+      expect(util.unpack_var_int_from_io(StringIO.new([0xfd, 0xff, 0xff].pack('C*')))).to eq(65535)
+      expect(util.unpack_var_int_from_io(StringIO.new([0xfe, 0x00, 0x00, 0x01, 0x00].pack('C*')))).to eq(65536)
+      expect(util.unpack_var_int_from_io(StringIO.new([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff].pack('C*')))).to eq(0xffffffffffffffff)
+      expect(util.unpack_var_int_from_io(StringIO.new([0xff].pack('C*')))).to be_nil
+      expect(util.unpack_var_int_from_io(StringIO.new)).to be_nil
     end
 
     it 'should pack boolean' do

--- a/spec/openassets/marker_output_spec.rb
+++ b/spec/openassets/marker_output_spec.rb
@@ -29,6 +29,22 @@ describe OpenAssets::MarkerOutput do
         script = Bitcoin::Script.new << OP_RETURN << '4f4102000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d71'
         expect(Bitcoin::TxOut.new(script_pubkey: script).open_assets_marker?).to be false
 
+        # can not parse varint
+        script = Bitcoin::Script.new << OP_RETURN << '4f410100ff'
+        expect(Bitcoin::TxOut.new(script_pubkey: script).open_assets_marker?).to be false
+
+        # can not decode leb128 data(invalid format)
+        script = Bitcoin::Script.new << OP_RETURN << '4f410100018f8f'
+        expect(Bitcoin::TxOut.new(script_pubkey: script).open_assets_marker?).to be false
+
+        # can not decode leb128 data(EOFError)
+        script = Bitcoin::Script.new << OP_RETURN << '4f410100028f7f'
+        expect(Bitcoin::TxOut.new(script_pubkey: script).open_assets_marker?).to be false
+
+        # no metadata length
+        script = Bitcoin::Script.new << OP_RETURN << '4f410100018f7f'
+        expect(Bitcoin::TxOut.new(script_pubkey: script).open_assets_marker?).to be false
+
         # invalid metadata length
         script = Bitcoin::Script.new << OP_RETURN << '4f4101000364007b1b753d68747470733a2f2f6370722e736d2f35596753553150672d' # short
         expect(Bitcoin::TxOut.new(script_pubkey: script).open_assets_marker?).to be false


### PR DESCRIPTION
Bitcoin users can set arbitrary OP_RETURN data to their own transactions.
So I think that OpenAssets::MarkerOutput#open_assets_marker method should return true/false value for any op_return data, but runtime error occurs for some payload such as '4f410100018f8f'.

```
irb(main):004:0>  script = Bitcoin::Script.new << Bitcoin::Opcodes::OP_RETURN << '4f410100018f8f'
=> #<Bitcoin::Script:0x00007fdf07ab1c68 @chunks=["j", "\aOA\x01\x00\x01\x8F\x8F"]>
irb(main):005:0> Bitcoin::TxOut.new(script_pubkey: script).open_assets_marker?
Traceback (most recent call last):
       10: from ./bin/console:14:in `<main>'
        9: from (irb):5
        8: from /Users/h_yamaguchi/Documents/Projects/chaintope/raijin_project/bitcoinrb/lib/openassets/marker_output.rb:8:in `open_assets_marker?'
        7: from /Users/h_yamaguchi/Documents/Projects/chaintope/raijin_project/bitcoinrb/lib/openassets/marker_output.rb:15:in `oa_payload'
        6: from /Users/h_yamaguchi/Documents/Projects/chaintope/raijin_project/bitcoinrb/lib/openassets/payload.rb:28:in `parse_from_payload'
        5: from /Users/h_yamaguchi/Documents/Projects/chaintope/raijin_project/bitcoinrb/lib/openassets/payload.rb:28:in `times'
        4: from /Users/h_yamaguchi/Documents/Projects/chaintope/raijin_project/bitcoinrb/lib/openassets/payload.rb:29:in `block in parse_from_payload'
        3: from /Users/h_yamaguchi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/leb128-1.0.0/lib/leb128.rb:69:in `decode_unsigned'
        2: from /Users/h_yamaguchi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/leb128-1.0.0/lib/leb128.rb:69:in `loop'
        1: from /Users/h_yamaguchi/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/gems/leb128-1.0.0/lib/leb128.rb:70:in `block in decode_unsigned'
NoMethodError (undefined method `unpack' for nil:NilClass)
irb(main):006:0> 
```