### PR TITLE
Fix `Bitcoin::RPC::BitcoinCoreClient` raises unexpected error.

### DIFF
--- a/bitcoinrb.gemspec
+++ b/bitcoinrb.gemspec
@@ -42,5 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'timecop'
+  spec.add_development_dependency 'webmock', '~> 3.0'
 
 end

--- a/lib/bitcoin/rpc/bitcoin_core_client.rb
+++ b/lib/bitcoin/rpc/bitcoin_core_client.rb
@@ -56,7 +56,7 @@ module Bitcoin
         post(server_url, @config[:timeout], @config[:open_timeout], data.to_json, content_type: :json) do |respdata, request, result|
           raise result.message if !result.kind_of?(Net::HTTPSuccess) && respdata.empty?
           response = JSON.parse(respdata.gsub(/\\u([\da-fA-F]{4})/) { [$1].pack('H*').unpack('n*').pack('U*').encode('ISO-8859-1').force_encoding('UTF-8') })
-          raise response['error'] if response['error']
+          raise response['error'].to_s if response['error']
           response['result']
         end
       end

--- a/spec/bitcoin/rpc/bitcoin_core_client_spec.rb
+++ b/spec/bitcoin/rpc/bitcoin_core_client_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Bitcoin::RPC::BitcoinCoreClient do
+
+  let!(:client) { 
+    # for Bitcoin::RPC::BitcoinCoreClient#initialize
+    stub_request(:post, server_url).to_return(body: JSON.generate({ 'result': 'rpc_command' }))
+    Bitcoin::RPC::BitcoinCoreClient.new(config)
+  }
+  let(:config) { {
+    schema: 'http',
+    host: 'localhost',
+    port: 18332,
+    user: 'xxx',
+    password: 'yyy'
+  } }
+  let(:server_url) { "#{config[:schema]}://#{config[:host]}:#{config[:port]}" }
+
+  describe '#{rpc_command}' do
+    it 'should return rpc response' do
+      stub_request(:post, server_url).to_return(
+        body: JSON.generate({ 'result': 'RESPONSE' })
+      )
+      expect(client.rpc_command).to eq('RESPONSE')
+    end
+    
+    context 'error on requesting' do
+      it 'should raise error' do
+        stub_request(:post, server_url).to_raise(StandardError.new('ERROR'))
+        expect { client.rpc_command }.to raise_error(StandardError, 'ERROR')
+      end
+    end
+
+    context 'server responded with error' do
+      it 'should raise with response' do
+        stub_request(:post, server_url).to_return(body: JSON.generate({ 'error': { 'code': '-1', 'message': 'RPC ERROR' } }))
+        expect { client.rpc_command }.to raise_error(RuntimeError, /RPC ERROR/)
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'bitcoin'
 require 'logger'
 require 'timecop'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.before(:each) do |example|


### PR DESCRIPTION
`Bitcoin::RPC::BitcoinCoreClient` raise `TypeError` when server respond with error messages, but expected to `RuntimeError`.
This pull-request is fix this.

```ruby
@client = Bitcoin::RPC::BitcoinCoreClient.new(config)

# before
@client.getblock("INVALID_BLOCK_HASH")
> TypeError (exception class/object expected)

# after
@client.getblock("INVALID_BLOCK_HASH")
> RuntimeError ({"code"=>-8, "message"=>"blockhash must be of length 64 (not 18, for 'INVALID_BLOCK_HASH')"})
```

Add  [WebMock](https://github.com/bblimke/webmock) gem for stubbing http-request in test.