### PR TITLE
Call CLI command on Ruby-like method names.

### DIFF
--- a/lib/bitcoin/rpc/bitcoin_core_client.rb
+++ b/lib/bitcoin/rpc/bitcoin_core_client.rb
@@ -65,6 +65,16 @@ module Bitcoin
         RestClient::Request.execute(method: :post, url: url, timeout: timeout,
                                     open_timeout: open_timeout, payload: payload, headers: headers, &block)
       end
+      
+      # Call CLI command on Ruby-like method names.
+      # e.g. generate_to_address, send_to_address, get_wallet_info
+      def method_missing(name, *args)
+        if name.to_s.include?('_')
+          send(name.to_s.gsub('_', '').to_sym, args)
+        else
+          super
+        end
+      end
 
     end
 


### PR DESCRIPTION
This pull-request is allow to call Bitcoin Core cli command on Ruby-like method names.

```ruby
@client = Bitcoin::RPC::BitcoinCoreClient.new(config)
@client.getblockcount
> 1
@client.get_block_count
> 1
```