### PR TITLE
Implement BIP47 Payment Code and notification address

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -55,6 +55,7 @@ module Bitcoin
   autoload :Descriptor, 'bitcoin/descriptor'
   autoload :SLIP39, 'bitcoin/slip39'
   autoload :Aezeed, 'bitcoin/aezeed'
+  autoload :PaymentCode, 'bitcoin/payment_code'
 
   require_relative 'bitcoin/constants'
 

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -43,9 +43,9 @@ module Bitcoin
     end
 
     # decode base58 encoded payment code
-    # @params [String] paymen_code_string base58 encoded payment code
-    def self.from_payment_code_string(paymen_code_string)
-      hex = Bitcoin::Base58.decode(paymen_code_string)
+    # @params [String] base58_payment_code base58 encoded payment code
+    def self.from_base58(base58_payment_code)
+      hex = Bitcoin::Base58.decode(base58_payment_code)
       row_payment_code = hex[0...-8]
       raise ArgumentError, 'invalid checksum' unless Bitcoin.calc_checksum(row_payment_code) == hex[-8..-1]
 

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -28,13 +28,13 @@ module Bitcoin
 
     # Base58 encoded payment code
     def to_base58
-      payment_code_with_version_byte = VERSION_BYTE + row_payment_code
+      payment_code_with_version_byte = VERSION_BYTE + to_payload.bth
       Bitcoin::Base58.encode(payment_code_with_version_byte + Bitcoin.calc_checksum(payment_code_with_version_byte))
     end
 
-    # get payment code
-    def row_payment_code
-      @version + @features_bits + @sign + @x_value + @chain_code.unpack('H*').first + @reserve_field
+    # serialize payment code
+    def to_payload
+      @version.htb << @features_bits.htb << @sign.htb << @x_value.htb << @chain_code << @reserve_field.htb
     end
 
     # get notification address
@@ -57,7 +57,7 @@ module Bitcoin
       payment_code_pubkey.x_value = x_value
       payment_code_pubkey.chain_code = [chain_code_hex].pack('H*')
 
-      payment_code_pubkey.row_payment_code
+      payment_code_pubkey.to_payload
     end
   end
 end

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -27,12 +27,13 @@ module Bitcoin
     end
 
     def payment_code
-      Bitcoin::Base58.encode(row_payment_code + Bitcoin.calc_checksum(row_payment_code))
+      payment_code_with_version_byte = VERSION_BYTE + row_payment_code
+      Bitcoin::Base58.encode(payment_code_with_version_byte + Bitcoin.calc_checksum(payment_code_with_version_byte))
     end
 
     # get payment code
     def row_payment_code
-      VERSION_BYTE + @version + @features_bits + @sign + @x_value + @chain_code.unpack('H*').first + @reserve_field
+      @version + @features_bits + @sign + @x_value + @chain_code.unpack('H*').first + @reserve_field
     end
 
     # get notification address

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -26,7 +26,8 @@ module Bitcoin
       payment_code
     end
 
-    def payment_code
+    # Base58 encoded payment code
+    def to_base58
       payment_code_with_version_byte = VERSION_BYTE + row_payment_code
       Bitcoin::Base58.encode(payment_code_with_version_byte + Bitcoin.calc_checksum(payment_code_with_version_byte))
     end

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -1,0 +1,53 @@
+module Bitcoin
+  class PaymentCode < ExtKey
+    attr_accessor :x_value
+
+    def initialize
+      @prefix = '47'
+      @version = '01'
+      @features_bits = '00'
+      @sign = '02'
+      @reserve_field = '0' * 26
+    end
+
+    def self.generate_master(seed)
+      master_ext_key = super.derive(47, harden=true).derive(0, harden=true).derive(0, harden=true)
+
+      payment_code = PaymentCode.new
+      payment_code.depth = master_ext_key.depth
+      payment_code.key = master_ext_key.key
+      payment_code.x_value = master_ext_key.pub.slice(2...master_ext_key.pub.length) # x of pubkey
+      payment_code.chain_code = master_ext_key.chain_code
+      payment_code
+    end
+
+    def payment_code
+      Bitcoin::Base58.encode(row_payment_code + Bitcoin.calc_checksum(row_payment_code))
+    end
+
+    def row_payment_code
+      @prefix + @version + @features_bits + @sign + @x_value + @chain_code.unpack('H*').first + @reserve_field
+    end
+
+    def notification_address
+      ext_pubkey.derive(0).addr
+    end
+
+    def self.from_payment_code_string(paymen_code_string)
+      hex = Bitcoin::Base58.decode(paymen_code_string)
+      row_payment_code = hex[0...-8]
+      raise ArgumentError, 'invalid checksum' unless Bitcoin.calc_checksum(row_payment_code) == hex[-8..-1]
+
+      x_value = row_payment_code[8..71]
+      chain_code_hex = row_payment_code[72..135]
+
+      payment_code_pubkey = PaymentCode.new
+      payment_code_pubkey.depth = 3
+      payment_code_pubkey.x_value = x_value
+      payment_code_pubkey.chain_code = [chain_code_hex].pack('H*')
+
+      payment_code_pubkey.row_payment_code
+    end
+  end
+end
+  

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -4,8 +4,9 @@ module Bitcoin
   class PaymentCode < ExtKey
     attr_accessor :x_value
 
+    VERSION_BYTE = '47'
+
     def initialize
-      @prefix = '47'
       @version = '01'
       @features_bits = '00'
       @sign = '02'
@@ -31,7 +32,7 @@ module Bitcoin
 
     # get payment code
     def row_payment_code
-      @prefix + @version + @features_bits + @sign + @x_value + @chain_code.unpack('H*').first + @reserve_field
+      VERSION_BYTE + @version + @features_bits + @sign + @x_value + @chain_code.unpack('H*').first + @reserve_field
     end
 
     # get notification address

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -46,11 +46,11 @@ module Bitcoin
     # @params [String] base58_payment_code base58 encoded payment code
     def self.from_base58(base58_payment_code)
       hex = Bitcoin::Base58.decode(base58_payment_code)
-      row_payment_code = hex[0...-8]
-      raise ArgumentError, 'invalid checksum' unless Bitcoin.calc_checksum(row_payment_code) == hex[-8..-1]
+      payment_code = hex[0...-8]
+      raise ArgumentError, 'invalid checksum' unless Bitcoin.calc_checksum(payment_code) == hex[-8..-1]
 
-      x_value = row_payment_code[8..71]
-      chain_code_hex = row_payment_code[72..135]
+      x_value = payment_code[8..71]
+      chain_code_hex = payment_code[72..135]
 
       payment_code_pubkey = PaymentCode.new
       payment_code_pubkey.depth = 3

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -6,6 +6,7 @@ module Bitcoin
 
     VERSION_BYTE = '47'
     SUPPORT_VERSIONS = ['01']
+    SUPPORT_SIGNS = ['02', '03']
 
     def initialize
       @version = '01'
@@ -49,7 +50,8 @@ module Bitcoin
       hex = Bitcoin::Base58.decode(base58_payment_code)
 
       raise ArgumentError, 'invalid version byte' unless hex[0..1] == VERSION_BYTE
-      raise ArgumentError, 'an unsupported version was detected' unless PaymentCode.support_version?(hex[2..3])
+      raise ArgumentError, 'invalid version' unless PaymentCode.support_version?(hex[2..3])
+      raise ArgumentError, 'invalid sign' unless PaymentCode.support_sign?(hex[6..7])
       payment_code = hex[0...-8]
       raise ArgumentError, 'invalid checksum' unless Bitcoin.calc_checksum(payment_code) == hex[-8..-1]
 
@@ -67,6 +69,11 @@ module Bitcoin
     # check whether +version+ is supported version bytes.
     def self.support_version?(version)
       SUPPORT_VERSIONS.include?(version)
+    end
+
+    # check whether +sign+ is supported version bytes.
+    def self.support_sign?(sign)
+      SUPPORT_SIGNS.include?(sign)
     end
 
   end

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -1,4 +1,6 @@
 module Bitcoin
+
+  # BIP47 payment code
   class PaymentCode < ExtKey
     attr_accessor :x_value
 
@@ -10,6 +12,8 @@ module Bitcoin
       @reserve_field = '0' * 26
     end
 
+    # generate master key from seed.
+    # @params [String] seed a seed data with hex format.
     def self.generate_master(seed)
       master_ext_key = super.derive(47, harden=true).derive(0, harden=true).derive(0, harden=true)
 
@@ -25,14 +29,18 @@ module Bitcoin
       Bitcoin::Base58.encode(row_payment_code + Bitcoin.calc_checksum(row_payment_code))
     end
 
+    # get payment code
     def row_payment_code
       @prefix + @version + @features_bits + @sign + @x_value + @chain_code.unpack('H*').first + @reserve_field
     end
 
+    # get notification address
     def notification_address
       ext_pubkey.derive(0).addr
     end
 
+    # decode base58 encoded payment code
+    # @params [String] paymen_code_string base58 encoded payment code
     def self.from_payment_code_string(paymen_code_string)
       hex = Bitcoin::Base58.decode(paymen_code_string)
       row_payment_code = hex[0...-8]

--- a/lib/bitcoin/payment_code.rb
+++ b/lib/bitcoin/payment_code.rb
@@ -5,6 +5,7 @@ module Bitcoin
     attr_accessor :x_value
 
     VERSION_BYTE = '47'
+    SUPPORT_VERSIONS = ['01']
 
     def initialize
       @version = '01'
@@ -46,6 +47,9 @@ module Bitcoin
     # @params [String] base58_payment_code base58 encoded payment code
     def self.from_base58(base58_payment_code)
       hex = Bitcoin::Base58.decode(base58_payment_code)
+
+      raise ArgumentError, 'invalid version byte' unless hex[0..1] == VERSION_BYTE
+      raise ArgumentError, 'an unsupported version was detected' unless PaymentCode.support_version?(hex[2..3])
       payment_code = hex[0...-8]
       raise ArgumentError, 'invalid checksum' unless Bitcoin.calc_checksum(payment_code) == hex[-8..-1]
 
@@ -59,6 +63,13 @@ module Bitcoin
 
       payment_code_pubkey.to_payload
     end
+
+    # check whether +version+ is supported version bytes.
+    def self.support_version?(version)
+      SUPPORT_VERSIONS.include?(version)
+    end
+
   end
+
 end
   

--- a/spec/bitcoin/payment_code_spec.rb
+++ b/spec/bitcoin/payment_code_spec.rb
@@ -10,7 +10,7 @@ describe Bitcoin::PaymentCode, network: :mainnet do
     end
 
     it 'generates Payment Code for Alice' do
-      expect(@payment_code.payment_code).to eq('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA')
+      expect(@payment_code.to_base58).to eq('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA')
     end
   end
 
@@ -20,7 +20,7 @@ describe Bitcoin::PaymentCode, network: :mainnet do
     end
 
     it 'generates Payment Code for Bob' do
-      expect(@payment_code.payment_code).to eq('PM8TJS2JxQ5ztXUpBBRnpTbcUXbUHy2T1abfrb3KkAAtMEGNbey4oumH7Hc578WgQJhPjBxteQ5GHHToTYHE3A1w6p7tU6KSoFmWBVbFGjKPisZDbP97')
+      expect(@payment_code.to_base58).to eq('PM8TJS2JxQ5ztXUpBBRnpTbcUXbUHy2T1abfrb3KkAAtMEGNbey4oumH7Hc578WgQJhPjBxteQ5GHHToTYHE3A1w6p7tU6KSoFmWBVbFGjKPisZDbP97')
     end
 
     it 'derive ECDH parameters' do
@@ -62,8 +62,8 @@ describe Bitcoin::PaymentCode, network: :mainnet do
 
   describe 'Decode Payment Code' do
     it 'decodes Base58 encoded payment code' do
-      expect(Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA')).to eq('47010002b85034fb08a8bfefd22848238257b252721454bbbfba2c3667f168837ea2cdad671af9f65904632e2dcc0c6ad314e11d53fc82fa4c4ea27a4a14eccecc478fee00000000000000000000000000')
-      expect{Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GB')}.to raise_error(ArgumentError, 'invalid checksum')
+      expect(Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth).to eq('010002b85034fb08a8bfefd22848238257b252721454bbbfba2c3667f168837ea2cdad671af9f65904632e2dcc0c6ad314e11d53fc82fa4c4ea27a4a14eccecc478fee00000000000000000000000000')
+      expect{Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GB').bth}.to raise_error(ArgumentError, 'invalid checksum')
     end
   end
 end

--- a/spec/bitcoin/payment_code_spec.rb
+++ b/spec/bitcoin/payment_code_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+# BIP-47 test
+# https://gist.github.com/SamouraiDev/6aad669604c5930864bd
+describe Bitcoin::PaymentCode, network: :mainnet do
+
+  describe "Alice's Wallet" do
+    before do
+      @payment_code = Bitcoin::PaymentCode.generate_master('64dca76abc9c6f0cf3d212d248c380c4622c8f93b2c425ec6a5567fd5db57e10d3e6f94a2f6af4ac2edb8998072aad92098db73558c323777abf5bd1082d970a')
+    end
+
+    it 'generates Payment Code for Alice' do
+      expect(@payment_code.payment_code).to eq('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA')
+  end
+  end
+
+  describe "Bob's Wallet" do
+    before do
+      @payment_code = Bitcoin::PaymentCode.generate_master('87eaaac5a539ab028df44d9110defbef3797ddb805ca309f61a69ff96dbaa7ab5b24038cf029edec5235d933110f0aea8aeecf939ed14fc20730bba71e4b1110')
+    end
+
+    it 'generates Payment Code for Bob' do
+      expect(@payment_code.payment_code).to eq('PM8TJS2JxQ5ztXUpBBRnpTbcUXbUHy2T1abfrb3KkAAtMEGNbey4oumH7Hc578WgQJhPjBxteQ5GHHToTYHE3A1w6p7tU6KSoFmWBVbFGjKPisZDbP97')
+    end
+
+    it 'derive ECDH parameters' do
+      expect(@payment_code.derive(0).priv).to eq('04448fd1be0c9c13a5ca0b530e464b619dc091b299b98c5cab9978b32b4a1b8b')
+      expect(@payment_code.derive(0).pub).to eq('024ce8e3b04ea205ff49f529950616c3db615b1e37753858cc60c1ce64d17e2ad8')
+      expect(@payment_code.derive(1).priv).to eq('6bfa917e4c44349bfdf46346d389bf73a18cec6bc544ce9f337e14721f06107b')
+      expect(@payment_code.derive(1).pub).to eq('03e092e58581cf950ff9c8fc64395471733e13f97dedac0044ebd7d60ccc1eea4d')
+      expect(@payment_code.derive(2).priv).to eq('46d32fbee043d8ee176fe85a18da92557ee00b189b533fce2340e4745c4b7b8c')
+      expect(@payment_code.derive(2).pub).to eq('029b5f290ef2f98a0462ec691f5cc3ae939325f7577fcaf06cfc3b8fc249402156')
+      expect(@payment_code.derive(3).priv).to eq('4d3037cfd9479a082d3d56605c71cbf8f38dc088ba9f7a353951317c35e6c343')
+      expect(@payment_code.derive(3).pub).to eq('02094be7e0eef614056dd7c8958ffa7c6628c1dab6706f2f9f45b5cbd14811de44')
+      expect(@payment_code.derive(4).priv).to eq('97b94a9d173044b23b32f5ab64d905264622ecd3eafbe74ef986b45ff273bbba')
+      expect(@payment_code.derive(4).pub).to eq('031054b95b9bc5d2a62a79a58ecfe3af000595963ddc419c26dab75ee62e613842')
+      expect(@payment_code.derive(5).priv).to eq('ce67e97abf4772d88385e66d9bf530ee66e07172d40219c62ee721ff1a0dca01')
+      expect(@payment_code.derive(5).pub).to eq('03dac6d8f74cacc7630106a1cfd68026c095d3d572f3ea088d9a078958f8593572')
+      expect(@payment_code.derive(6).priv).to eq('ef049794ed2eef833d5466b3be6fe7676512aa302afcde0f88d6fcfe8c32cc09')
+      expect(@payment_code.derive(6).pub).to eq('02396351f38e5e46d9a270ad8ee221f250eb35a575e98805e94d11f45d763c4651')
+      expect(@payment_code.derive(7).priv).to eq('d3ea8f780bed7ef2cd0e38c5d943639663236247c0a77c2c16d374e5a202455b')
+      expect(@payment_code.derive(7).pub).to eq('039d46e873827767565141574aecde8fb3b0b4250db9668c73ac742f8b72bca0d0')
+      expect(@payment_code.derive(8).priv).to eq('efb86ca2a3bad69558c2f7c2a1e2d7008bf7511acad5c2cbf909b851eb77e8f3')
+      expect(@payment_code.derive(8).pub).to eq('038921acc0665fd4717eb87f81404b96f8cba66761c847ebea086703a6ae7b05bd')
+      expect(@payment_code.derive(9).priv).to eq('18bcf19b0b4148e59e2bba63414d7a8ead135a7c2f500ae7811125fb6f7ce941')
+      expect(@payment_code.derive(9).pub).to eq('03d51a06c6b48f067ff144d5acdfbe046efa2e83515012cf4990a89341c1440289')
+    end
+  end
+
+  describe "Alice's notification transaction to Bob" do
+    before do
+      @alice_payment_code = Bitcoin::PaymentCode.generate_master('64dca76abc9c6f0cf3d212d248c380c4622c8f93b2c425ec6a5567fd5db57e10d3e6f94a2f6af4ac2edb8998072aad92098db73558c323777abf5bd1082d970a')
+      @bob_payment_code = Bitcoin::PaymentCode.generate_master('87eaaac5a539ab028df44d9110defbef3797ddb805ca309f61a69ff96dbaa7ab5b24038cf029edec5235d933110f0aea8aeecf939ed14fc20730bba71e4b1110')
+    end
+
+    it 'generates notification address' do
+      expect(@alice_payment_code.notification_address).to eq('1JDdmqFLhpzcUwPeinhJbUPw4Co3aWLyzW')
+      expect(@bob_payment_code.notification_address).to eq('1ChvUUvht2hUQufHBXF8NgLhW8SwE2ecGV')
+      expect(@bob_payment_code.derive(0).pub).to eq('024ce8e3b04ea205ff49f529950616c3db615b1e37753858cc60c1ce64d17e2ad8')
+    end
+  end
+
+  describe 'Decode Payment Code' do
+    it 'decodes Base58 encoded payment code' do
+      expect(Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA')).to eq('47010002b85034fb08a8bfefd22848238257b252721454bbbfba2c3667f168837ea2cdad671af9f65904632e2dcc0c6ad314e11d53fc82fa4c4ea27a4a14eccecc478fee00000000000000000000000000')
+      expect{Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GB')}.to raise_error(ArgumentError, 'invalid checksum')
+    end
+  end
+end

--- a/spec/bitcoin/payment_code_spec.rb
+++ b/spec/bitcoin/payment_code_spec.rb
@@ -67,6 +67,7 @@ describe Bitcoin::PaymentCode, network: :mainnet do
       expect{Bitcoin::PaymentCode.from_base58('AM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth}.to raise_error(ArgumentError, 'invalid version byte')
       expect{Bitcoin::PaymentCode.from_base58('PMCbB5gHcpvkWfGPAz1QYR7X9jFwYvwc8rJTCK4VAzADbs9DoQUyr2r23aXfTUYtDjunfQcUUwjRWzAKqi4PDzyK2ftyoPAkkFsVQRxHP7PyxxgGunwu').bth}.to raise_error(ArgumentError, 'invalid version')
       expect{Bitcoin::PaymentCode.from_base58('PM8TJrebgLcDCJa1ygSPNa3hrcG1C4t9j7MEKGVCep5MdnUsUZDPhW2oyA5P4H4N3KXauS4JSjj4gFikc6zdFz2ByvZ9dBvorEeKBZCydK5BMwrgNfyu').bth}.to raise_error(ArgumentError, 'invalid sign')
+      expect{Bitcoin::PaymentCode.from_base58('PM8TJVeCupU7EcGA3XXTAfNRybqxPhdHa1NAPfYof2W9u4vuBhBEW7sdm6WYJRoYMEYm867vZyEbpDANpPEjGWc7HnYWMiMnDt6EFZubsjjvMNChusQi').bth}.to raise_error(ArgumentError, 'invalid public key')
     end
   end
 end

--- a/spec/bitcoin/payment_code_spec.rb
+++ b/spec/bitcoin/payment_code_spec.rb
@@ -11,7 +11,7 @@ describe Bitcoin::PaymentCode, network: :mainnet do
 
     it 'generates Payment Code for Alice' do
       expect(@payment_code.payment_code).to eq('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA')
-  end
+    end
   end
 
   describe "Bob's Wallet" do

--- a/spec/bitcoin/payment_code_spec.rb
+++ b/spec/bitcoin/payment_code_spec.rb
@@ -62,8 +62,8 @@ describe Bitcoin::PaymentCode, network: :mainnet do
 
   describe 'Decode Payment Code' do
     it 'decodes Base58 encoded payment code' do
-      expect(Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth).to eq('010002b85034fb08a8bfefd22848238257b252721454bbbfba2c3667f168837ea2cdad671af9f65904632e2dcc0c6ad314e11d53fc82fa4c4ea27a4a14eccecc478fee00000000000000000000000000')
-      expect{Bitcoin::PaymentCode.from_payment_code_string('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GB').bth}.to raise_error(ArgumentError, 'invalid checksum')
+      expect(Bitcoin::PaymentCode.from_base58('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth).to eq('010002b85034fb08a8bfefd22848238257b252721454bbbfba2c3667f168837ea2cdad671af9f65904632e2dcc0c6ad314e11d53fc82fa4c4ea27a4a14eccecc478fee00000000000000000000000000')
+      expect{Bitcoin::PaymentCode.from_base58('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GB').bth}.to raise_error(ArgumentError, 'invalid checksum')
     end
   end
 end

--- a/spec/bitcoin/payment_code_spec.rb
+++ b/spec/bitcoin/payment_code_spec.rb
@@ -64,6 +64,8 @@ describe Bitcoin::PaymentCode, network: :mainnet do
     it 'decodes Base58 encoded payment code' do
       expect(Bitcoin::PaymentCode.from_base58('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth).to eq('010002b85034fb08a8bfefd22848238257b252721454bbbfba2c3667f168837ea2cdad671af9f65904632e2dcc0c6ad314e11d53fc82fa4c4ea27a4a14eccecc478fee00000000000000000000000000')
       expect{Bitcoin::PaymentCode.from_base58('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GB').bth}.to raise_error(ArgumentError, 'invalid checksum')
+      expect{Bitcoin::PaymentCode.from_base58('AM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth}.to raise_error(ArgumentError, 'invalid version byte')
+      expect{Bitcoin::PaymentCode.from_base58('PMCbB5gHcpvkWfGPAz1QYR7X9jFwYvwc8rJTCK4VAzADbs9DoQUyr2r23aXfTUYtDjunfQcUUwjRWzAKqi4PDzyK2ftyoPAkkFsVQRxHP7PyxxgGunwu').bth}.to raise_error(ArgumentError, 'an unsupported version was detected')
     end
   end
 end

--- a/spec/bitcoin/payment_code_spec.rb
+++ b/spec/bitcoin/payment_code_spec.rb
@@ -65,7 +65,8 @@ describe Bitcoin::PaymentCode, network: :mainnet do
       expect(Bitcoin::PaymentCode.from_base58('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth).to eq('010002b85034fb08a8bfefd22848238257b252721454bbbfba2c3667f168837ea2cdad671af9f65904632e2dcc0c6ad314e11d53fc82fa4c4ea27a4a14eccecc478fee00000000000000000000000000')
       expect{Bitcoin::PaymentCode.from_base58('PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GB').bth}.to raise_error(ArgumentError, 'invalid checksum')
       expect{Bitcoin::PaymentCode.from_base58('AM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA').bth}.to raise_error(ArgumentError, 'invalid version byte')
-      expect{Bitcoin::PaymentCode.from_base58('PMCbB5gHcpvkWfGPAz1QYR7X9jFwYvwc8rJTCK4VAzADbs9DoQUyr2r23aXfTUYtDjunfQcUUwjRWzAKqi4PDzyK2ftyoPAkkFsVQRxHP7PyxxgGunwu').bth}.to raise_error(ArgumentError, 'an unsupported version was detected')
+      expect{Bitcoin::PaymentCode.from_base58('PMCbB5gHcpvkWfGPAz1QYR7X9jFwYvwc8rJTCK4VAzADbs9DoQUyr2r23aXfTUYtDjunfQcUUwjRWzAKqi4PDzyK2ftyoPAkkFsVQRxHP7PyxxgGunwu').bth}.to raise_error(ArgumentError, 'invalid version')
+      expect{Bitcoin::PaymentCode.from_base58('PM8TJrebgLcDCJa1ygSPNa3hrcG1C4t9j7MEKGVCep5MdnUsUZDPhW2oyA5P4H4N3KXauS4JSjj4gFikc6zdFz2ByvZ9dBvorEeKBZCydK5BMwrgNfyu').bth}.to raise_error(ArgumentError, 'invalid sign')
     end
   end
 end


### PR DESCRIPTION
# Improvements made by this PR
Implement v1 of [BIP47](https://github.com/bitcoin/bips/blob/master/bip-0047.mediawiki#Abstract) Payment Code to bitcoinrb.  
This PR achieved following features.
- Generate Payment Code
- Decode Payment Code
- Generate notification address

# Required further works
- Notification transaction
- Sending transaction
- Whole v2 implementation

