### PR TITLE
Feature UTXO handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ Bitcoin.chain_params = :regtest
 
 This parameter is described in https://github.com/chaintope/bitcoinrb/blob/master/lib/bitcoin/chainparams/regtest.yml.
 
-### Running SPV node
+### Running SPV node(Experimental)
 
-Bitcoinrb supports SPV node.
+> :warning: **This is experimental**
+> Implementation for SPV node feature is still in development.
+> Don't use bitcoinrb as SPV node for production.
+
 The following is the sample code to run as SPV node.
 
 The SPV node connect to 3 peers("172.18.1.1", "172.18.1.2", "172.18.1.3") and then receive messages(tx, headers, merkleblock, ...) from these peers.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,40 @@ Bitcoin.chain_params = :regtest
 
 This parameter is described in https://github.com/chaintope/bitcoinrb/blob/master/lib/bitcoin/chainparams/regtest.yml.
 
+### Running SPV node
+
+Bitcoinrb supports SPV node.
+The following is the sample code to run as SPV node.
+
+The SPV node connect to 3 peers("172.18.1.1", "172.18.1.2", "172.18.1.3") and then receive messages(tx, headers, merkleblock, ...) from these peers.
+
+```ruby
+c = Bitcoin::Node::Configuration.new(network: :regtest, connect:["172.18.1.1", "172.18.1.2", "172.18.1.3"])
+spv = Bitcoin::Node::SPV.new(c)
+spv.wallet = Bitcoin::Wallet::Base.create(1)
+Thread.start{ spv.run }
+```
+
+If you need to manage UTXOs associated with SPV wallet, use `Bitcoin::Store::UtxoDB` and `Bitcoin::Wallet::UtxoHandler`
+
+```ruby
+utxo_db = Bitcoin::Store::UtxoDB.new
+utxo_handler = Bitcoin::Wallet::UtxoHandler.new(spv, utxo_db)
+```
+
+After initializing `Bitcoin::Wallet::UtxoHandler`, SPV node starts to receive tx messages from connected peers and store the received utxo into the database. 
+You can get the list of utxo associated with the wallet via `Bitcoin::Store::UtxoDB#list_unspent_in_account` and get balance via `Bitcoin::Store::UtxoDB#get_balance`
+
+```ruby
+account = spv.wallet.accounts.first
+
+# list unspent
+utxo_db.list_unspent_in_account(account)
+
+# get balance
+utxo_db.get_balance(account)
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/bitcoinrb. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/bitcoin/wallet.rb
+++ b/lib/bitcoin/wallet.rb
@@ -5,5 +5,6 @@ module Bitcoin
     autoload :DB, 'bitcoin/wallet/db'
     autoload :MasterKey, 'bitcoin/wallet/master_key'
     autoload :Utxo, 'bitcoin/wallet/utxo'
+    autoload :UtxoHandler, 'bitcoin/wallet/utxo_handler'
   end
 end

--- a/lib/bitcoin/wallet/utxo_handler.rb
+++ b/lib/bitcoin/wallet/utxo_handler.rb
@@ -1,0 +1,55 @@
+module Bitcoin
+  module Wallet
+    class UtxoHandler
+      attr_reader :watchings, :spv, :utxo_db, :pendings
+
+      # @param spv [Bitcoin::Node::SPV]
+      # @utxo_db [Bitcoin::Store::UtxoDb]
+      def initialize(spv, utxo_db)
+        @spv = spv
+        @spv.add_observer(self)
+        @utxo_db = utxo_db
+        @logger = Bitcoin::Logger.create(:debug)
+      end
+
+      def update(event, data)
+        @logger.debug "UtxoHandler#update: #{event}, #{data}"
+        send(event, data)
+      end
+
+      private
+
+      # Called when receiving `tx` message from other node.
+      #
+      # - Store utxo if the output of received tx is in the watch list
+      # - Delete from utxo_db for spent output.
+      def tx(data)
+        tx = data.tx
+        tx.outputs.each_with_index do |output, index|
+          next unless watching?(output)
+          out_point = Bitcoin::OutPoint.new(tx.tx_hash, index)
+          utxo_db.save_utxo(out_point, output.value, output.script_pubkey)
+        end
+
+        tx.inputs.each do |input|
+          utxo_db.delete_utxo(input.out_point)
+        end
+      end
+
+      def header(data)
+      end
+
+      def merkleblock(data)
+      end
+
+      # Return if specified output is contained in watch_targets
+      def watching?(output)
+        return false unless spv.wallet
+        watch_targets = spv.wallet.watch_targets
+        watch_targets.find do |target|
+          output.script_pubkey.to_hex.include?(target)
+        end
+      end
+    end
+  end
+end

--- a/lib/bitcoin/wallet/utxo_handler.rb
+++ b/lib/bitcoin/wallet/utxo_handler.rb
@@ -37,9 +37,11 @@ module Bitcoin
       end
 
       def header(data)
+        # No implementation
       end
 
       def merkleblock(data)
+        # No implementation
       end
 
       # Return if specified output is contained in watch_targets

--- a/lib/bitcoin/wallet/utxo_handler.rb
+++ b/lib/bitcoin/wallet/utxo_handler.rb
@@ -1,7 +1,7 @@
 module Bitcoin
   module Wallet
     class UtxoHandler
-      attr_reader :watchings, :spv, :utxo_db, :pendings
+      attr_reader :watchings, :spv, :utxo_db, :pending_blocks, :pending_txs
 
       # @param spv [Bitcoin::Node::SPV]
       # @utxo_db [Bitcoin::Store::UtxoDb]
@@ -10,6 +10,8 @@ module Bitcoin
         @spv.add_observer(self)
         @utxo_db = utxo_db
         @logger = Bitcoin::Logger.create(:debug)
+        @pending_blocks = []
+        @pending_txs = []
       end
 
       def update(event, data)
@@ -19,7 +21,7 @@ module Bitcoin
 
       private
 
-      # Called when receiving `tx` message from other node.
+      # Called when receiving `tx` message from the connecting peers.
       #
       # - Store utxo if the output of received tx is in the watch list
       # - Delete from utxo_db for spent output.
@@ -34,14 +36,41 @@ module Bitcoin
         tx.inputs.each do |input|
           utxo_db.delete_utxo(input.out_point)
         end
+
+        pending_txs << tx
       end
 
+      # Called when receiving `header` message from connecting peers.
+      #
+      # if block is contained in pending list, call save_tx_position
       def header(data)
-        # No implementation
+        block_height = data[:height]
+        block_hash = data[:hash]
+
+        pending_blocks.each do |pending_merkleblock|
+          tx_blockhash = pending_merkleblock.header.block_hash
+          block = spv.chain.find_entry_by_hash(tx_blockhash)
+          if block
+            save_tx_position(pending_merkleblock, block)
+            pending_blocks.delete(pending_merkleblock)
+          end
+        end
       end
 
+      # Called when receiving `merkleblock` message from connecting peers.
+      #
+      # if spv has block:
+      #     save position of the transaction,
+      # otherwise:
+      #     data is cached in the pending list. this data is handled when node receive `header` message.
       def merkleblock(data)
-        # No implementation
+        tx_blockhash = data.header.block_hash
+        block = spv.chain.find_entry_by_hash(tx_blockhash)
+        if block
+          save_tx_position(data, block)
+        else
+          pending_blocks << data
+        end
       end
 
       # Return if specified output is contained in watch_targets
@@ -51,6 +80,18 @@ module Bitcoin
         watch_targets.find do |target|
           output.script_pubkey.to_hex.include?(target)
         end
+      end
+
+      # Save tx position(block height, and index in the block)
+      def save_tx_position(data, block)
+        tree = Bitcoin::MerkleTree.build_partial(data.tx_count, data.hashes, Bitcoin.byte_to_bit(data.flags.htb))
+        block_height = block.height
+        pending_txs.each do |item|
+            tx_index = tree.find_node(item.tx_hash)&.index
+            next unless tx_index
+            utxo_db.save_tx_position(item.tx_hash, block_height, tx_index)
+            pending_txs.delete(item)
+          end
       end
     end
   end

--- a/spec/bitcoin/wallet/utxo_handler_spec.rb
+++ b/spec/bitcoin/wallet/utxo_handler_spec.rb
@@ -22,7 +22,7 @@ describe 'Bitcoin::Wallet::UtxoHandler' do
       key = wallet.accounts.first.create_receive
 
       # default script is native_segwit
-      script = Bitcoin::Script.to_p2wpkh(Bitcoin.hash160(key.pubkey))
+      script = Bitcoin::Script.to_p2wpkh(key.hash160)
       Bitcoin::Tx.new.tap do |tx|
         tx.inputs << Bitcoin::TxIn.new(out_point: Bitcoin::OutPoint.new('00' * 32, -1))
         tx.outputs << Bitcoin::TxOut.new(value: 600, script_pubkey: script)

--- a/spec/bitcoin/wallet/utxo_handler_spec.rb
+++ b/spec/bitcoin/wallet/utxo_handler_spec.rb
@@ -109,6 +109,11 @@ describe 'Bitcoin::Wallet::UtxoHandler' do
       it 'delete from pending blocks' do
         expect { subject }.to change { handler.pending_blocks.size }.from(1).to(0)
       end
+
+      it 'can retrieve by block height' do
+        subject
+        expect(utxo_db.list_unspent(current_block_height: 100015, min: 1, max: 1, addresses: nil).size).to eq 1
+      end
     end
   end
 
@@ -146,6 +151,11 @@ describe 'Bitcoin::Wallet::UtxoHandler' do
 
       it 'delete from pending txs' do
         expect { subject }.to change { handler.pending_txs.size }.from(1).to(0)
+      end
+
+      it 'can retrieve by block height' do
+        subject
+        expect(utxo_db.list_unspent(current_block_height: 100015, min: 1, max: 1, addresses: nil).size).to eq 1
       end
     end
   end

--- a/spec/bitcoin/wallet/utxo_handler_spec.rb
+++ b/spec/bitcoin/wallet/utxo_handler_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe 'Bitcoin::Wallet::UtxoHandler' do
+  let(:handler) { Bitcoin::Wallet::UtxoHandler.new(spv, utxo_db) }
+  let(:utxo_db) { create_test_utxo_db }
+  let(:spv) { create_test_spv }
+  let(:wallet) { Bitcoin::Wallet::Base.create(1, 'tmp/wallet_db/') }
+
+  before { allow(spv).to receive(:wallet).and_return(wallet) }
+
+  after do
+    utxo_db.close
+    wallet.close
+    FileUtils.rm_r('tmp/wallet_db/')
+  end
+
+  context 'when node receives tx message' do
+    subject { handler.update(:tx, message) }
+
+    let(:funding_tx) do
+      # create transaction to send to the wallet
+      key = wallet.accounts.first.create_receive
+
+      # default script is native_segwit
+      script = Bitcoin::Script.to_p2wpkh(Bitcoin.hash160(key.pubkey))
+      Bitcoin::Tx.new.tap do |tx|
+        tx.inputs << Bitcoin::TxIn.new(out_point: Bitcoin::OutPoint.new('00' * 32, -1))
+        tx.outputs << Bitcoin::TxOut.new(value: 600, script_pubkey: script)
+      end
+    end
+    let(:out_point) { Bitcoin::OutPoint.from_txid(funding_tx.txid, 0)}
+
+    context 'store utxo' do
+      let(:message) { Bitcoin::Message::Tx.parse_from_payload(funding_tx.to_payload) }
+
+      it 'should store watching utxo' do
+        subject
+        utxo = utxo_db.get_utxo(out_point)
+        expect(utxo).not_to be_nil
+
+        utxos = utxo_db.list_unspent_in_account(wallet.accounts.first)
+        expect(utxos.size).to eq 1
+      end
+    end
+
+    context 'delete utxo' do
+      before do
+        output = funding_tx.outputs[0];
+        utxo_db.save_utxo(out_point, output.value, output.script_pubkey)
+      end
+
+      let(:message) { Bitcoin::Message::Tx.parse_from_payload(spending_tx.to_payload) }
+      let(:spending_tx) do
+        Bitcoin::Tx.new.tap do |tx|
+          tx.inputs << Bitcoin::TxIn.new(out_point: Bitcoin::OutPoint.from_txid(funding_tx.txid, 0))
+          # No outputs
+        end
+      end
+
+      it 'should delete unspent utxo from utxo_db' do
+        expect(utxo_db.get_utxo(out_point)).not_to be_nil
+        subject
+        expect(utxo_db.get_utxo(out_point)).to be_nil
+        utxos = utxo_db.list_unspent_in_account(wallet.accounts.first)
+        expect(utxos.size).to eq 0
+      end
+    end
+  end
+
+  context 'when node receives header message' do
+    subject { handler.update(:header, {hash: '00' * 32, height: 101}) }
+
+    it { expect { subject }.not_to raise_error }
+  end
+
+  context 'when receive merkleblock message' do
+    subject { handler.update(:merkleblock, merkle_block) }
+
+    let(:payload) { '0100000082bb869cf3a793432a66e826e05a6fc37469f8efb7421dc880670100000000007f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d9728776381b4d4c86041b554b852907000000043612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b6541ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d06820d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf011d'.htb }
+    let(:merkle_block) { Bitcoin::Message::MerkleBlock.parse_from_payload(payload) }
+
+    it { expect { subject }.not_to raise_error }
+  end
+end

--- a/spec/bitcoin/wallet/utxo_handler_spec.rb
+++ b/spec/bitcoin/wallet/utxo_handler_spec.rb
@@ -45,7 +45,7 @@ describe 'Bitcoin::Wallet::UtxoHandler' do
 
     context 'delete utxo' do
       before do
-        output = funding_tx.outputs[0];
+        output = funding_tx.outputs[0]
         utxo_db.save_utxo(out_point, output.value, output.script_pubkey)
       end
 

--- a/spec/bitcoin/wallet/utxo_handler_spec.rb
+++ b/spec/bitcoin/wallet/utxo_handler_spec.rb
@@ -70,15 +70,83 @@ describe 'Bitcoin::Wallet::UtxoHandler' do
   context 'when node receives header message' do
     subject { handler.update(:header, {hash: '00' * 32, height: 101}) }
 
-    it { expect { subject }.not_to raise_error }
+    # https://www.blockchain.com/btc/block/100014
+    let(:payload) { '0100000082bb869cf3a793432a66e826e05a6fc37469f8efb7421dc880670100000000007f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d9728776381b4d4c86041b554b852907000000043612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b6541ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d06820d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf011d'.htb }
+    let(:merkle_block) { Bitcoin::Message::MerkleBlock.parse_from_payload(payload) }
+
+    # https://www.blockchain.com/btc/tx/652b0aa4cf4f17bdb31f7a1d308331bba91f3b3cbf8f39c9cb5e19d4015b9f01
+    let(:tx) { Bitcoin::Tx.parse_from_payload('0100000001834537b2f1ce8ef9373a258e10545ce5a50b758df616cd4356e0032554ebd3c4000000008b483045022100e68f422dd7c34fdce11eeb4509ddae38201773dd62f284e8aa9d96f85099d0b002202243bd399ff96b649a0fad05fa759d6a882f0af8c90cf7632c2840c29070aec20141045e58067e815c2f464c6a2a15f987758374203895710c2d452442e28496ff38ba8f5fd901dc20e29e88477167fe4fc299bf818fd0d9e1632d467b2a3d9503b1aaffffffff0280d7e636030000001976a914f34c3e10eb387efe872acb614c89e78bfca7815d88ac404b4c00000000001976a914a84e272933aaf87e1715d7786c51dfaeb5b65a6f88ac00000000'.htb) }
+    let(:out_point) { Bitcoin::OutPoint.from_txid('652b0aa4cf4f17bdb31f7a1d308331bba91f3b3cbf8f39c9cb5e19d4015b9f01', 0) }
+    let(:script_pubkey) { Bitcoin::Script.parse_from_addr('n3hPq5zGqvQKCtLu3r2szQ5b1oAzBdfY9S') }
+
+    let(:header) { Bitcoin::BlockHeader.parse_from_payload('0100000082bb869cf3a793432a66e826e05a6fc37469f8efb7421dc880670100000000007f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d9728776381b4d4c86041b554b8529'.htb) }
+
+    context 'if merkleblock does not have received' do
+      before do
+        handler.pending_txs << tx
+        utxo_db.save_utxo(out_point, 13_806_000_000, script_pubkey)
+        allow(spv.chain).to receive(:find_entry_by_hash).and_return(Bitcoin::Store::ChainEntry.new(header, 100014))
+      end
+
+      it 'should not change block_height of the UTXO' do
+        expect { subject }.not_to change { utxo_db.get_utxo(out_point).block_height }
+      end
+
+    end
+
+    context 'if merkleblock has already received' do
+      before do
+        handler.pending_blocks << merkle_block
+        handler.pending_txs << tx
+        utxo_db.save_utxo(out_point, 13_806_000_000, script_pubkey)
+        allow(spv.chain).to receive(:find_entry_by_hash).and_return(Bitcoin::Store::ChainEntry.new(header, 100014))
+      end
+
+      it 'update block_height of the UTXO' do
+        expect { subject }.to change { utxo_db.get_utxo(out_point).block_height }.from(nil).to(100014)
+      end
+
+      it 'delete from pending blocks' do
+        expect { subject }.to change { handler.pending_blocks.size }.from(1).to(0)
+      end
+    end
   end
 
   context 'when receive merkleblock message' do
     subject { handler.update(:merkleblock, merkle_block) }
 
+    # https://www.blockchain.com/btc/block/100014
     let(:payload) { '0100000082bb869cf3a793432a66e826e05a6fc37469f8efb7421dc880670100000000007f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d9728776381b4d4c86041b554b852907000000043612262624047ee87660be1a707519a443b1c1ce3d248cbfc6c15870f6c5daa2019f5b01d4195ecbc9398fbf3c3b1fa9bb3183301d7a1fb3bd174fcfa40a2b6541ed70551dd7e841883ab8f0b16bf04176b7d1480e4f0af9f3d4c3595768d06820d2a7bc994987302e5b1ac80fc425fe25f8b63169ea78e68fbaaefa59379bbf011d'.htb }
     let(:merkle_block) { Bitcoin::Message::MerkleBlock.parse_from_payload(payload) }
 
-    it { expect { subject }.not_to raise_error }
+    let(:header) { Bitcoin::BlockHeader.parse_from_payload('0100000082bb869cf3a793432a66e826e05a6fc37469f8efb7421dc880670100000000007f16c5962e8bd963659c793ce370d95f093bc7e367117b3c30c1f8fdd0d9728776381b4d4c86041b554b8529'.htb) }
+
+    context 'if node has not received header yet' do
+      it 'add merkleblock to pending list' do
+        allow(spv.chain).to receive(:find_entry_by_hash).and_return(nil)
+        expect { subject }.to change { handler.pending_blocks.size }.from(0).to(1)
+      end
+    end
+
+    context 'if node has received header' do
+      # https://www.blockchain.com/btc/tx/652b0aa4cf4f17bdb31f7a1d308331bba91f3b3cbf8f39c9cb5e19d4015b9f01
+      let(:tx) { Bitcoin::Tx.parse_from_payload('0100000001834537b2f1ce8ef9373a258e10545ce5a50b758df616cd4356e0032554ebd3c4000000008b483045022100e68f422dd7c34fdce11eeb4509ddae38201773dd62f284e8aa9d96f85099d0b002202243bd399ff96b649a0fad05fa759d6a882f0af8c90cf7632c2840c29070aec20141045e58067e815c2f464c6a2a15f987758374203895710c2d452442e28496ff38ba8f5fd901dc20e29e88477167fe4fc299bf818fd0d9e1632d467b2a3d9503b1aaffffffff0280d7e636030000001976a914f34c3e10eb387efe872acb614c89e78bfca7815d88ac404b4c00000000001976a914a84e272933aaf87e1715d7786c51dfaeb5b65a6f88ac00000000'.htb) }
+      let(:out_point) { Bitcoin::OutPoint.from_txid('652b0aa4cf4f17bdb31f7a1d308331bba91f3b3cbf8f39c9cb5e19d4015b9f01', 0) }
+      let(:script_pubkey) { Bitcoin::Script.parse_from_addr('n3hPq5zGqvQKCtLu3r2szQ5b1oAzBdfY9S') }
+
+      before do
+        utxo_db.save_utxo(out_point, 13_806_000_000, script_pubkey)
+        handler.pending_txs << tx
+        allow(spv.chain).to receive(:find_entry_by_hash).and_return(Bitcoin::Store::ChainEntry.new(header, 100014))
+      end
+
+      it 'update block_height of the UTXO' do
+        expect { subject }.to change { utxo_db.get_utxo(out_point).block_height }.from(nil).to(100014)
+      end
+
+      it 'delete from pending txs' do
+        expect { subject }.to change { handler.pending_txs.size }.from(1).to(0)
+      end
+    end
   end
 end

--- a/spec/bitcoin/wallet/utxo_handler_spec.rb
+++ b/spec/bitcoin/wallet/utxo_handler_spec.rb
@@ -4,14 +4,14 @@ describe 'Bitcoin::Wallet::UtxoHandler' do
   let(:handler) { Bitcoin::Wallet::UtxoHandler.new(spv, utxo_db) }
   let(:utxo_db) { create_test_utxo_db }
   let(:spv) { create_test_spv }
-  let(:wallet) { Bitcoin::Wallet::Base.create(1, 'tmp/wallet_db/') }
+  let(:wallet) { create_test_wallet }
 
   before { allow(spv).to receive(:wallet).and_return(wallet) }
 
   after do
     utxo_db.close
     wallet.close
-    FileUtils.rm_r('tmp/wallet_db/')
+    FileUtils.rm_r(test_wallet_path(1))
   end
 
   context 'when node receives tx message' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,6 +79,20 @@ def create_test_utxo_db()
   Bitcoin::Store::UtxoDB.new(TEST_UTXO_DB_PATH)
 end
 
+def create_test_spv
+  block = double('block')
+  allow(block).to receive(:height).and_return(101)
+
+  chain = double('chain')
+  allow(chain).to receive(:latest_block).and_return(block)
+
+  spv = double('spv')
+  allow(spv).to receive(:chain).and_return(chain)
+  allow(spv).to receive(:broadcast).and_return(nil)
+  allow(spv).to receive(:add_observer).and_return(nil)
+  spv
+end
+
 module Bitcoin
   autoload :TestScriptParser, 'bitcoin/script/test_script_parser'
 end


### PR DESCRIPTION
This PR adds UTXO handler to save UTXOs and delete UTXOs from the database.

As described in README.md, SPV node start to collect UTXOs associated with wallet when utxo handler is initialized.

Note that 

- We can handle `merkleblock` message in order to save the position of tx in the block but this PR does not contain it.
Block height of UTXO is useful when we need to know UTXO is confirmed deeply (e.g. 6 confirmation) or not.
- SPV node should update the bloomfilter and send `filteradd` message when adding the keypair in the wallet using `Bitcoin::Wallet::Base#generate_new_address` or other API.
