### PR TITLE
Fix multi wallet support.

### DIFF
--- a/lib/bitcoin/rpc/bitcoin_core_client.rb
+++ b/lib/bitcoin/rpc/bitcoin_core_client.rb
@@ -56,7 +56,7 @@ module Bitcoin
         uri = URI.parse(server_url)
         http = Net::HTTP.new(uri.hostname, uri.port)
         http.use_ssl = uri.scheme === "https"
-        request = Net::HTTP::Post.new('/')
+        request = Net::HTTP::Post.new(uri.path.empty? ? '/' : uri.path)
         request.basic_auth(uri.user, uri.password)
         request.content_type = 'application/json'
         request.body = data.to_json

--- a/spec/bitcoin/rpc/bitcoin_core_client_spec.rb
+++ b/spec/bitcoin/rpc/bitcoin_core_client_spec.rb
@@ -46,6 +46,15 @@ describe Bitcoin::RPC::BitcoinCoreClient do
         expect(client.rpc_command['amount']).to eq("0.08495981")
       end
     end
+
+    context 'wallet is specified in config' do
+      let(:config) { super().merge({ wallet: 'mywallet' }) }
+      let(:server_url) { "#{config[:schema]}://#{config[:host]}:#{config[:port]}/wallet/#{config[:wallet]}" }
+      it 'should have wallet name in the path like "/wallet/[wallet_name]"' do
+        assert_requested(:post, server_url)
+        client.rpc_command
+      end
+    end
   end
   
   describe '#method_missing' do


### PR DESCRIPTION
BitcoinCoreClient is expected to send requests with `/wallet/[wallet_name]` path, when `config[:wallet]` is set.
However the current impl is not work as that.
This PR is going to fix it.