### PR TITLE
Fix opcode method to use ord

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -133,14 +133,7 @@ module Bitcoin
 
     # get opcode
     def opcode
-      case encoding
-      when Encoding::ASCII_8BIT
-        each_byte.next
-      when Encoding::US_ASCII
-        ord
-      else
-        to_i
-      end
+      force_encoding(Encoding::ASCII_8BIT).ord
     end
 
     def opcode?

--- a/spec/bitcoin_spec.rb
+++ b/spec/bitcoin_spec.rb
@@ -37,6 +37,17 @@ describe Bitcoin do
       expect(OP_PUSHDATA1.chr.opcode).to eq(OP_PUSHDATA1)
       expect('1446c2fbfbecc99a63148fa076de58cf29b0bcf0b0'.htb.opcode?).to be false
     end
+
+    context 'different character code' do
+      it 'should be return same opcode' do
+        expect(OP_1.chr.opcode).to eq(OP_1)
+        expect(OP_1.chr.force_encoding("US-ASCII").opcode).to eq(OP_1)
+        expect(OP_1.chr.force_encoding("UTF-8").opcode).to eq(OP_1)
+        expect(OP_SIZE.chr.opcode).to eq(OP_SIZE)
+        expect(OP_SIZE.chr.force_encoding("US-ASCII").opcode).to eq(OP_SIZE)
+        expect(OP_SIZE.chr.force_encoding("UTF-8").opcode).to eq(OP_SIZE)
+      end
+    end
   end
 
   describe '#pushed_data' do


### PR DESCRIPTION
Changed to use ord because each_byte method was slow.
Benchmark results are listed below.

```
# use this rawtransaction
raw_tx = "01000000000101cdf9ce825aba7f777899cc76243946a62d9ecb6c9805d30faa5a690d862344d70000000000ffffffff0253a2800200000000160014e3324f11cd2d4715c9d09186d0677d3f18fc0cc8e8c61100000000001976a91498cba7ee7618b76d19b4952a4240b954609b75cb88ac0247304402204ed43722821e458b98295824079ad4a04f5a55df8aa3339e89ebc7138d45e1ca022076b925a51996eb2797a0f870855d73220950e7a91d5d8f0cc11bc9e2c68551ba012103e67c2c0435bd1b6478ae327e4746d788a01e2f6e669506cb1a0515b9a708c74b00000000"
```

【before】
```ruby
irb > n = 100000
irb > Benchmark.bm do |x|
irb >   x.report { n.times do ; Bitcoin::Tx.parse_from_payload(raw_tx.htb); end }
irb > end
       user     system      total        real
   5.003670   0.378110   5.381780 (  5.390959)
=> [#<Benchmark::Tms:0x00007f92ea0fbd18 @label="", @real=5.390958999982104, @cstime=0.0, @cutime=0.0, @stime=0.37811000000000006, @utime=5.00367, @total=5.38178>]
```

【after】
```ruby
irb >   n = 100000
irb > Benchmark.bm do |x|
irb >   x.report { n.times do ; Bitcoin::Tx.parse_from_payload(raw_tx.htb); end }
irb > end
       user     system      total        real
   2.513904   0.006857   2.520761 (  2.527589)
=> [#<Benchmark::Tms:0x00007fa3e71ffe40 @label="", @real=2.5275890000048093, @cstime=0.0, @cutime=0.0, @stime=0.006857000000000002, @utime=2.513904, @total=2.5207610000000003>]
```