### PR TITLE
Add WITNESS_V1_TAPROOT type to P2TR output scripts

### DIFF
--- a/lib/bitcoin/script/script.rb
+++ b/lib/bitcoin/script/script.rb
@@ -555,6 +555,7 @@ module Bitcoin
       return 'multisig' if multisig?
       return 'witness_v0_keyhash' if p2wpkh?
       return 'witness_v0_scripthash' if p2wsh?
+      return 'witness_v1_taproot' if p2tr?
       'nonstandard'
     end
 

--- a/spec/bitcoin/script/script_spec.rb
+++ b/spec/bitcoin/script/script_spec.rb
@@ -187,6 +187,7 @@ describe Bitcoin::Script do
       expect(subject.standard?).to be true
       expect(subject.p2pk?).to be false
       expect(subject.to_addr).to eq('bc1p5rgvqejqh9dh37t9g94dd9cm8vtqns7dndgj423egwggsggcdzmsspvr7j')
+      expect(subject.type).to eq('witness_v1_taproot')
     end
 
     context 'invalid P2TR' do


### PR DESCRIPTION
Bitcoin::Script#type returns `nonstandard` for p2tr output scripts.

This patch changes this behaviour to return `WITNESS_V1_TAPROOT` for the `type` method instead.