### PR TITLE
Remove idle buf.eof check

### DIFF
--- a/lib/bitcoin/script/script.rb
+++ b/lib/bitcoin/script/script.rb
@@ -146,7 +146,7 @@ module Bitcoin
                 end
           if buf.eof?
             s.chunks << [len].pack('C')
-          else buf.eof?
+          else
             chunk = (packed_size ? (opcode + packed_size) : (opcode)) + buf.read(len)
             s.chunks << chunk
           end


### PR DESCRIPTION
When going through the code stumbled upon this one. Was a bit confusing. No noticeable effect on the time of running the specs (8 minutes and 25 seconds)