### PR TITLE
Allow testing on linux using a custom TEST_LIBSECP256K1_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Therefore, some tests require this library. In a Linux environment, `spec/lib/li
 so there is no need to do anything. If you want to test in another environment,
 please set the library path in the environment variable `TEST_LIBSECP256K1_PATH`.
 
+In case the supplied linux `spec/lib/libsecp256k1.so` is not working (architecture), you might have to compile it yourself.
+Since if available in the repository, it might not be compiled using the `./configure --enable-module-recovery` option.
+Then `TEST_LIBSECP256K1_PATH=/path/to/secp256k1/.libs/libsecp256k1.so rspec` can be used.
+
 The libsecp256k1 library currently tested for operation with this library is `v0.4.0`.
 
 ## Contributing

--- a/lib/bitcoin/secp256k1/native.rb
+++ b/lib/bitcoin/secp256k1/native.rb
@@ -7,7 +7,7 @@ module Bitcoin
     # binding for secp256k1 (https://github.com/bitcoin-core/secp256k1/)
     # tag: v0.4.0
     # this is not included by default, to enable set shared object path to ENV['SECP256K1_LIB_PATH']
-    # for linux, ENV['SECP256K1_LIB_PATH'] = '/usr/local/lib/libsecp256k1.so'
+    # for linux, ENV['SECP256K1_LIB_PATH'] = '/usr/local/lib/libsecp256k1.so' or '/usr/lib64/libsecp256k1.so'
     # for mac,
     module Native
       include ::FFI::Library

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ def use_secp256k1
   host_os = RbConfig::CONFIG['host_os']
   case host_os
   when /linux/
-    ENV['SECP256K1_LIB_PATH'] = File.expand_path('lib/libsecp256k1.so', File.dirname(__FILE__))
+    ENV['SECP256K1_LIB_PATH'] = ENV['TEST_LIBSECP256K1_PATH'] || File.expand_path('lib/libsecp256k1.so', File.dirname(__FILE__))
   else
     if ENV['LIBSECP_PATH']
       ENV['SECP256K1_LIB_PATH'] = ENV['TEST_LIBSECP256K1_PATH']


### PR DESCRIPTION
When running the specs on an Apple M1 machine running Fedora linux there were some problems using the secp256k1 library. The changes of this request should allow running all the specs on these (and other) type of linux machines.